### PR TITLE
Perf update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To make logs more useful we need additional metadata (like names, locations in t
 Babel-plugin is built-in in the `effector` package.
 
 Just add it to your babel configuration.
+
 ```json
 {
   "plugins": ["effector/babel-plugin"]
@@ -49,33 +50,57 @@ Just call `attachReduxDevTools()` somewhere in your project's entrypoint and you
 // e.g. src/main.ts
 import { attachReduxDevTools } from "@effector/redux-devtools-adapter";
 
-attachReduxDevTools()
+attachReduxDevTools();
 ```
 
-You can also provide some additional configuration. Example:
+You can also provide some additional configuration. All fields are optional.
+
+#### name
+
+Type: `string`.
+Will be visible in the Redux Devtools
+
+#### scope
+
+Type: `Scope`
+Effector's Scope from Fork API, if your app uses it.
+
+See [the docs](https://effector.dev/docs/api/effector/scope/) and [the article](https://dev.to/effector/the-best-part-of-effector-4c27)
+
+#### trace
+
+Type: `boolean`
+Enables traces of effector's calculations in the actions. Disabled by default.
+
+#### batch
+
+Type: `boolean | { size: number; latency: number; }`.
+Enables batching of logs at the adapter's side. Redux DevTools are trying to print each and every log they get, which may cause performance issues in the large apps.
+
+With batching enabled adapter sends logs only once in `latency` milliseconds and with number of logs no more than `size` number.
+This means that only last `size` number of logs will be visible in the DevTools at all times.
+
+Enabled by default, defautls are: last 100 logs with timeout milliseconds.
+
+### stateTab
+
+Type: `boolean`.
+Enables state tab with state of all stores at each point in time. May cause performance issues in the large apps. Disabled by default.
+
+#### devToolsConfig
+
+Config for Redux DevTools, passed directly to the `connect` call.
+See [the official docs](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md).
+
+Example of configurated call:
+
 ```ts
 import { attachReduxDevTools } from "@effector/redux-devtools-adapter";
 
 attachReduxDevTools({
-  name: "(Optional) Name of your app, will be visible in the Redux DevTools",
+  name: "My App",
   scope,
-  /**
-   * ☝️ (optional) effector's Scope, if you use it
-   *
-   * @see https://effector.dev/docs/api/effector/scope/
-   * @see https://dev.to/effector/the-best-part-of-effector-4c27
-   */
   trace: true,
-  /**
-   * ☝️ enables traces of effector's calculations for every log. Optional, `false` by default
-   */
-  devToolsConfig,
-  /**
-   *
-   * Redux DevTools extension config
-   *
-   * @see https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md
-   */
 });
 ```
 
@@ -86,4 +111,3 @@ attachReduxDevTools({
 1. Update labels for PRs and titles, next [manually run the release drafter action](https://github.com/effector/redux-devtools-adapter/actions/workflows/release-drafter.yml) to regenerate the draft release.
 1. Review the new version and press "Publish"
 1. If required check "Create discussion for this release"
-

--- a/demo-app/app.tsx
+++ b/demo-app/app.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fork } from "effector";
 import { Provider } from "effector-react";
 import { CounterView } from "./counter";
+import { HeavyCounterView } from "./stress-test-counter";
 
 export const scopeOne = fork();
 export const scopeTwo = fork();
@@ -11,20 +12,36 @@ export function App() {
     <main>
       <div>
         <h1>No Scope</h1>
-        <CounterView />
+        <AppBody />
       </div>
       <div>
         <h1>With Scope 1</h1>
         <Provider value={scopeOne}>
-          <CounterView />
+          <AppBody />
         </Provider>
       </div>
       <div>
         <h1>With Scope 2 (traces)</h1>
         <Provider value={scopeTwo}>
-          <CounterView />
+          <AppBody />
         </Provider>
       </div>
     </main>
+  );
+}
+
+function AppBody() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexFlow: "column",
+        gap: 8,
+        alignItems: "flex-start",
+      }}
+    >
+      <CounterView />
+      <HeavyCounterView />
+    </div>
   );
 }

--- a/demo-app/main.ts
+++ b/demo-app/main.ts
@@ -12,8 +12,9 @@ attachReduxDevTools({
 });
 
 attachReduxDevTools({
-  name: "Demo app (scope)",
+  name: "Demo app (scope + batch)",
   scope: scopeOne,
+  batch: true,
 });
 
 attachReduxDevTools({

--- a/demo-app/stress-test-counter/index.ts
+++ b/demo-app/stress-test-counter/index.ts
@@ -1,0 +1,1 @@
+export {HeavyCounterView} from "./ui";

--- a/demo-app/stress-test-counter/model.ts
+++ b/demo-app/stress-test-counter/model.ts
@@ -5,7 +5,7 @@ const increment = createEvent();
 export const $heavyCounter = createStore(0).on(increment, (state) => state + 1);
 
 const incrementManyFx = createEffect(() => {
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     increment();
   }
 });

--- a/demo-app/stress-test-counter/model.ts
+++ b/demo-app/stress-test-counter/model.ts
@@ -1,0 +1,16 @@
+import { createStore, createEvent, createEffect, sample } from "effector";
+
+export const buttonClicked = createEvent();
+const increment = createEvent();
+export const $heavyCounter = createStore(0).on(increment, (state) => state + 1);
+
+const incrementManyFx = createEffect(() => {
+  for (let i = 0; i < 100; i++) {
+    increment();
+  }
+});
+
+sample({
+  clock: buttonClicked,
+  target: incrementManyFx,
+});

--- a/demo-app/stress-test-counter/ui.tsx
+++ b/demo-app/stress-test-counter/ui.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { useUnit } from "effector-react";
+import { buttonClicked, $heavyCounter } from "./model";
+
+export function HeavyCounterView() {
+  const { click, count } = useUnit({
+    click: buttonClicked,
+    count: $heavyCounter,
+  });
+
+  return (
+    <button onClick={click} style={{ ["--color-link" as any]: "crimson" }}>
+      HEAVY COUNT: {count}
+    </button>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,7 @@ function createBatcher(
   const { maxAge, latency } =
     typeof settings === "object" ? { ...defaults, ...settings } : defaults;
 
-  let queue = [] as {
+  const queue = [] as {
     log: Record<string, unknown>;
     state: Record<string, unknown>;
   }[];
@@ -335,7 +335,6 @@ function createBatcher(
         devToolsController.send(item.log, item.state);
       }
     }
-    queue = [];
   }, latency);
 
   return (log: Record<string, unknown>) => {


### PR DESCRIPTION
- Added batching at the adapter side. Redux DevTools are trying to render each and every log by default, `maxAge` setting only restricts how many logs are rendered at once. At large apps it really bad for perf, especially if we count in the serialization overhead. Adapter's internal batching allows to mitigiate this issue a bit by not sending any more logs than specified in the batch setting. This way there are bit less overhead for serialization and rendering. 
- Added special setting for the `stateTab` and disabled it by default.
- State tab produces are a lot of overhead on serialization at the somewhat large apps.
